### PR TITLE
change `devtool` to `cheap-module-eval-source-map`

### DIFF
--- a/webpack.config.dev.babel.js
+++ b/webpack.config.dev.babel.js
@@ -7,7 +7,7 @@ module.exports = new WebpackConfig().extend('./webpack.config.common.babel.js').
     pathinfo: true
   },
   debug: true,
-  devtool: '#eval',
+  devtool: '#cheap-module-eval-source-map',
   entry: {
     bundle: path.join(__dirname,'/app/script.js')
   }


### PR DESCRIPTION
Looking at transpiled code might confuse students and not be very helpful. Changing it to this will still have better performance than some other options while still showing original source code